### PR TITLE
Fixed missing discount bug for new accounts

### DIFF
--- a/woocommerce-bulk-discount.php
+++ b/woocommerce-bulk-discount.php
@@ -440,6 +440,10 @@ if ( !class_exists( 'Woo_Bulk_Discount_Plugin_t4m' ) ) {
 				return;
 			}
 
+			if ( !$this->bulk_discount_calculated) {
+				return;
+			}
+
 			if ( sizeof( $cart->cart_contents ) > 0 ) {
 				foreach ( $cart->cart_contents as $cart_item_key => $values ) {
 					$_product = $values['data'];
@@ -448,6 +452,9 @@ if ( !class_exists( 'Woo_Bulk_Discount_Plugin_t4m' ) ) {
 					}
 					$values['data']->set_price( $this->discount_coeffs[$this->get_actual_id( $_product )]['orig_price'] );
 				}
+
+				$this->bulk_discount_calculated = false;
+
 			}
 
 		}


### PR DESCRIPTION
[As](https://wordpress.org/support/topic/disounts-are-randomly-not-applied) [many](https://wordpress.org/support/topic/bulk-discount-missing-from-final-price) [people](https://wordpress.org/support/topic/new-customers-not-getting-discount) [have](https://wordpress.org/support/topic/plugin-not-applying-discount) [reported](https://wordpress.org/support/topic/discount-removed-at-checkout), sometimes the intended bulk discount mysteriously disappears when the customer confirms the checkout, meaning they are forced to pay the full, undiscounted price.

I've found that this can be reliably reproduced by creating a new account on the checkout screen. The bug does not occur when checking out from an existing account, or checking out as a guest.

As you can see [here](http://docs.woothemes.com/wc-apidocs/source-class-WC_Checkout.html#592), when a new account is created, the checkout is refreshed and the totals are calculated again. This results in the original, undiscounted price being sent along to the payment processor.

With the attached fix, it calculates the correct, discounted total, even when a new account is created during checkout. Please incorporate this fix as soon as possible - many store owners will thank you.
